### PR TITLE
Add initial u8darts recipe

### DIFF
--- a/recipes/u8darts/meta.yaml
+++ b/recipes/u8darts/meta.yaml
@@ -1,0 +1,63 @@
+{% set version = "0.9.1" %}
+{% set pypi_package_name = "u8darts" %}
+{% set data = load_setup_py_data() %}
+
+package:
+  name: "u8darts"
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ pypi_package_name[0] }}/{{ pypi_package_name }}/{{ pypi_package_name }}-{{ version }}.tar.gz
+  sha256: 344ee13b3d60d7500009c8b1b993f29be5d3cab701c3744521ec7f0c980543c9
+
+build:
+  number: 0
+  noarch: python
+  script: '{{ PYTHON }} -m pip install . --no-deps -vv'
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+
+  run:
+    - python >=3.7
+  {% for req in data.get('install_requires', []) %}
+    - {{ req | replace("torch", "pytorch") | replace(">=", " >=")}}
+  {% endfor %}
+
+test:
+  imports:
+    - darts
+    - darts.dataprocessing
+    - darts.dataprocessing.transformers
+    - darts.datasets
+    - darts.metrics
+    - darts.models
+    - darts.tests
+    - darts.tests.dataprocessing
+    - darts.tests.dataprocessing.transformers
+    - darts.tests.utils
+    - darts.utils
+    - darts.utils.data
+  source_files:
+    - darts
+  commands:
+    - python -m unittest
+  requires:
+    - pip
+    - testfixtures
+
+about:
+  home: {{ data.get('url') }}
+  license: {{ data.get('license') }}
+  license_family: APACHE
+  license_file: LICENSE
+  summary: {{ data.get('description') }}
+
+extra:
+  recipe-maintainers:
+    - unit8co
+    - unit8-bot
+    - hrzn
+    - tomasvanpottelbergh

--- a/recipes/u8darts/meta.yaml
+++ b/recipes/u8darts/meta.yaml
@@ -1,6 +1,5 @@
 {% set version = "0.9.1" %}
 {% set pypi_package_name = "u8darts" %}
-{% set data = load_setup_py_data() %}
 
 package:
   name: "u8darts"
@@ -22,9 +21,19 @@ requirements:
 
   run:
     - python >=3.7
-  {% for req in data.get('install_requires', []) %}
-    - {{ req | replace("torch", "pytorch") | replace(">=", " >=")}}
-  {% endfor %}
+    - numpy >=1.19.0
+    - xarray >=0.18.0
+    - scipy >=1.6.0
+    - statsmodels >=0.12.0
+    - matplotlib >=3.4.0
+    - pandas >=1.2.0,<1.3.0
+    - ipython >=7.22.0
+    - tqdm >=4.60.0
+    - holidays >=0.11.0
+    - scikit-learn >=0.24.0
+    - filterpy >=1.4.5
+    - joblib >=1.0.0
+    - requests >=2.25.0
 
 test:
   imports:
@@ -49,11 +58,13 @@ test:
     - testfixtures
 
 about:
-  home: {{ data.get('url') }}
-  license: {{ data.get('license') }}
+  home: https://unit8co.github.io/darts/
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  summary: {{ data.get('description') }}
+  summary: A python library for easy manipulation and forecasting of time series.
+  dev_url: https://github.com/unit8co/darts
+  doc_url: https://unit8co.github.io/darts/
 
 extra:
   recipe-maintainers:

--- a/recipes/u8darts/meta.yaml
+++ b/recipes/u8darts/meta.yaml
@@ -57,7 +57,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - unit8co
-    - unit8-bot
     - hrzn
     - tomasvanpottelbergh

--- a/recipes/u8darts/meta.yaml
+++ b/recipes/u8darts/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - xarray >=0.18.0
     - scipy >=1.6.0
     - statsmodels >=0.12.0
-    - matplotlib >=3.4.0
+    - matplotlib-base >=3.4.0
     - pandas >=1.2.0,<1.3.0
     - ipython >=7.22.0
     - tqdm >=4.60.0


### PR DESCRIPTION
This would add a conda package called 'u8darts', linked to the PyPI 'u8darts' package. This means only the core requirements will be installed. I think this is the best way to avoid confusion because of differences between conda and PyPI packages.

It would be possible to create variants such as 'u8darts-all' and 'u8darts-torch', see the pytorch feedstock for an example.